### PR TITLE
chore(ci): guard releases to the main branch (#61)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate branch
+        if: github.ref_name != 'main'
+        run: |
+          echo "::error::Releases are only allowed from the main branch."
+          exit 1
+
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
Adds a Validate branch step to release.yml so package releases only run from main, not from arbitrary branches. Closes #61.